### PR TITLE
Add Sqsh support to ska_dbi

### DIFF
--- a/ska_dbi/DBI.py
+++ b/ska_dbi/DBI.py
@@ -3,20 +3,15 @@
 ska_dbi provides simple methods for database access and data insertion.
 Features:
 
-- Sqlite and sybase connections are supported.
-- Automatic fetching of Ska database account passwords.
+- Sqlite connections are supported.
 - Integration with numpy record arrays.
 - Verbose mode to show transaction information.
-- Insert method smooths over syntax differences between sqlite and sybase.
 """
 import os
 import sys
+import sqlite3 as dbapi2
 from ska_dbi.common import DEFAULT_CONFIG, NoPasswordError
 
-if sys.version_info.major == 3 and sys.version_info.minor < 11:
-    SUPPORTED_DBIS = ('sqlite', 'sybase')
-else:
-    SUPPORTED_DBIS = ('sqlite')
 
 def _denumpy(x):
     """
@@ -35,14 +30,10 @@ class DBI(object):
     Example usage::
 
       db = DBI(dbi='sqlite', server=dbfile, numpy=False, verbose=True)
-      db = DBI(dbi='sybase', server='sqlsao', user='aca_ops', database='axafapstat')
-      db = DBI(dbi='sybase')   # Use defaults (same as above)
 
-    :param dbi:  Database interface name (sqlite, sybase)
+    :param dbi:  Database interface name (sqlite)
     :param server: Server name (or file name for sqlite)
     :param user: User name (optional)
-    :param passwd: Password (optional).  Read from aspect authorization if required and not supplied.
-    :param database: Database name for sybase (default = SKA_DATABASE env. or package default 'aca').
     :param autocommit: Automatically commit after each transaction.  Slower but easier to code.
     :param numpy:  Return multirow results as numpy.recarray; input vals can be numpy types
     :param verbose: Print transaction info
@@ -50,22 +41,16 @@ class DBI(object):
 
     :rtype: DBI object
     """
-    def __init__(self, dbi=None, server=None, user=None, passwd=None, database=None,
+    def __init__(self, dbi=None, server=None,
                  numpy=True, autocommit=True, verbose=False,
-                 authdir='/proj/sot/ska/data/aspect_authorization',
                  **kwargs):
 
 
-        if dbi not in SUPPORTED_DBIS:
-            raise ValueError(f'dbi = {dbi} not supported - allowed = {SUPPORTED_DBIS}')
+        if dbi != 'sqlite':
+            raise ValueError(f'ska_dbi.DBI only supports sqlite at this time.  Got {dbi}.')
 
         self.dbi = dbi
         self.server = server or DEFAULT_CONFIG[dbi].get('server')
-        self.user = user or DEFAULT_CONFIG[dbi].get('user')
-        self.database = (database
-                         or os.environ.get('SKA_DATABASE')
-                         or DEFAULT_CONFIG[dbi].get('database'))
-        self.passwd = passwd
         self.numpy = numpy
         self.autocommit = autocommit
         self.verbose = verbose
@@ -73,30 +58,7 @@ class DBI(object):
         if self.verbose:
             print('Connecting to', self.dbi, 'server', self.server)
 
-        if dbi == 'sqlite':
-            import sqlite3 as dbapi2
-            self.conn = dbapi2.connect(self.server)
-
-        elif dbi == 'sybase':
-            if 'SYBASE_OCS' not in os.environ:
-                raise ValueError(
-                    'SYBASE_OCS env variable not defined. sybase dbi works only in production ska.')
-            modulepath = os.path.join(os.environ['SYBASE'], os.environ['SYBASE_OCS'],
-                                      'python', 'python39_64r', 'lib')
-            if not os.path.exists(modulepath):
-                raise ValueError(f"{modulepath} does not exist on system.")
-            sys.path.insert(0, modulepath)
-            import sybpydb as dbapi2
-            if self.passwd is None:
-                try:
-                    passwd_file = os.path.join(authdir, '%s-%s-%s' % (self.server, self.database, self.user))
-                    self.passwd = open(passwd_file).read().strip()
-                    if self.verbose:
-                        print('Using password from', passwd_file)
-                except IOError as e:
-                    raise NoPasswordError("None supplied and unable to read password file %s" % e)
-            self.conn = dbapi2.connect(servername=self.server, user=self.user, password=self.passwd)
-
+        self.conn = dbapi2.connect(self.server)
         self.Error = dbapi2.Error
 
     def __enter__(self):
@@ -132,11 +94,6 @@ class DBI(object):
         """
         # Get a new cursor (implicitly closing any previous cursor)
         self.cursor = self.conn.cursor()
-
-        # Sybase dbi does not handle database via the connection.
-        # Must be requested via the cursor.
-        if self.dbi == 'sybase':
-            self.cursor.execute(f'use {self.database}')
 
         for subexpr in expr.split(';\n'):
             if vals is not None:
@@ -254,8 +211,6 @@ class DBI(object):
         # Create the insert command depending on dbi.  Start with the column
         # value replacement strings
         colrepls = ('?',) * len(cols)
-        if self.dbi == 'sybase' and replace:
-            raise ValueError('Using replace=True not allowed for Sybase DBI')
 
         insert_str = "INSERT %s INTO %s (%s) VALUES (%s)"
         replace_str = replace and 'OR REPLACE' or ''

--- a/ska_dbi/DBI.py
+++ b/ska_dbi/DBI.py
@@ -11,9 +11,12 @@ Features:
 """
 import os
 import sys
+from ska_dbi.common import DEFAULT_CONFIG, NoPasswordError
 
-supported_dbis = ('sqlite', 'sybase')
-
+if sys.version_info.major == 3 and sys.version_info.minor < 11:
+    SUPPORTED_DBIS = ('sqlite', 'sybase')
+else:
+    SUPPORTED_DBIS = ('sqlite')
 
 def _denumpy(x):
     """
@@ -25,14 +28,6 @@ def _denumpy(x):
         return x
 
 
-class NoPasswordError(Exception):
-    """
-    Special Error for the case when password is neither supplied nor available
-    from a file.
-    """
-    pass
-
-
 class DBI(object):
     """
     Database interface class.
@@ -40,7 +35,7 @@ class DBI(object):
     Example usage::
 
       db = DBI(dbi='sqlite', server=dbfile, numpy=False, verbose=True)
-      db = DBI(dbi='sybase', server='sybase', user='aca_ops', database='aca')
+      db = DBI(dbi='sybase', server='sqlsao', user='aca_ops', database='axafapstat')
       db = DBI(dbi='sybase')   # Use defaults (same as above)
 
     :param dbi:  Database interface name (sqlite, sybase)
@@ -60,20 +55,16 @@ class DBI(object):
                  authdir='/proj/sot/ska/data/aspect_authorization',
                  **kwargs):
 
-        DEFAULTS = {'sqlite': {'server': 'db.sql3'},
-                    'sybase': {'server': 'sybase',
-                               'user': 'aca_ops',
-                               'database': 'aca'}}
 
-        if dbi not in supported_dbis:
-            raise ValueError('dbi = %s not supported - allowed = %s' % (dbi, supported_dbis))
+        if dbi not in SUPPORTED_DBIS:
+            raise ValueError(f'dbi = {dbi} not supported - allowed = {SUPPORTED_DBIS}')
 
         self.dbi = dbi
-        self.server = server or DEFAULTS[dbi].get('server')
-        self.user = user or DEFAULTS[dbi].get('user')
+        self.server = server or DEFAULT_CONFIG[dbi].get('server')
+        self.user = user or DEFAULT_CONFIG[dbi].get('user')
         self.database = (database
                          or os.environ.get('SKA_DATABASE')
-                         or DEFAULTS[dbi].get('database'))
+                         or DEFAULT_CONFIG[dbi].get('database'))
         self.passwd = passwd
         self.numpy = numpy
         self.autocommit = autocommit

--- a/ska_dbi/__init__.py
+++ b/ska_dbi/__init__.py
@@ -2,6 +2,7 @@
 import ska_helpers
 
 from .DBI import *
+from .sqsh import Sqsh
 
 __version__ = ska_helpers.get_version('ska_dbi')
 

--- a/ska_dbi/__init__.py
+++ b/ska_dbi/__init__.py
@@ -2,7 +2,6 @@
 import ska_helpers
 
 from .DBI import *
-from .sqsh import Sqsh
 
 __version__ = ska_helpers.get_version('ska_dbi')
 

--- a/ska_dbi/common.py
+++ b/ska_dbi/common.py
@@ -1,0 +1,12 @@
+DEFAULT_CONFIG = {'sqlite': {'server': 'db.sql3'},
+                  'sybase': {'server': 'sqlsao',
+                             'user': 'aca_ops',
+                             'database': 'axafapstat'}}
+
+
+class NoPasswordError(Exception):
+    """
+    Special Error for the case when password is neither supplied nor available
+    from a file.
+    """
+    pass

--- a/ska_dbi/sqsh.py
+++ b/ska_dbi/sqsh.py
@@ -64,8 +64,6 @@ class Sqsh(object):
         """
         Context manager exit run time context.
         """
-        pass
-
 
     def fetch(self, query):
         """

--- a/ska_dbi/sqsh.py
+++ b/ska_dbi/sqsh.py
@@ -4,10 +4,7 @@ from astropy.table import Table
 from ska_dbi.common import DEFAULT_CONFIG, NoPasswordError
 
 SYBASE = "/soft/SYBASE16.0"
-ENV_VARS = [
-    f"SYBASE={SYBASE}",
-    "LD_LIBRARY_PATH=/soft/SYBASE16.0/OCS-16_0/lib:/soft/SYBASE16.0/OCS-16_0/lib3p64:/soft/SYBASE16.0/OCS-16_0/lib3p",
-]
+LD_LIBRARY_PATH = "/soft/SYBASE16.0/OCS-16_0/lib:/soft/SYBASE16.0/OCS-16_0/lib3p64:/soft/SYBASE16.0/OCS-16_0/lib3p"
 SQSH_BIN = "/usr/local/bin/sqsh.bin"
 
 
@@ -87,9 +84,11 @@ class Sqsh(object):
         -------
         list of str
         """
-        envs = ENV_VARS
+        cmd_env = {"SYBASE": SYBASE,
+                   "LD_LIBRARY_PATH": LD_LIBRARY_PATH}
         if self.sqshrc is not None:
-            envs = envs + [f"SQSHRC={self.sqshrc}"]
+            cmd_env['SQSHRC'] = self.sqshrc
+
         cmd = [
             SQSH_BIN,
             "-X",
@@ -104,10 +103,9 @@ class Sqsh(object):
             "-C",
             query,
         ]
-        cmd = ["env"] + envs + cmd
 
         proc = subprocess.Popen(
-            cmd, stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE
+            cmd, stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE, env=cmd_env,
         )
         stdout, stderr = proc.communicate()
         if proc.returncode != 0:

--- a/ska_dbi/sqsh.py
+++ b/ska_dbi/sqsh.py
@@ -108,7 +108,6 @@ class Sqsh(object):
         outlines = stdout.decode().splitlines()
         return outlines
 
-
     def fetchall(self, query):
         """
         Fetches all the rows returned by the query.
@@ -127,7 +126,6 @@ class Sqsh(object):
         outlines = self.fetch(query)
         tab = Table.read(outlines, format="ascii.csv")
         return tab
-
 
     def fetchone(self, query):
         """

--- a/ska_dbi/sqsh.py
+++ b/ska_dbi/sqsh.py
@@ -102,15 +102,9 @@ class Sqsh(object):
             query,
         ]
 
-        proc = subprocess.Popen(
-            cmd, stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE, env=cmd_env,
+        stdout = subprocess.check_output(
+            cmd, env=cmd_env,
         )
-        stdout, stderr = proc.communicate()
-        if proc.returncode != 0:
-            raise RuntimeError(
-                "sqsh failed with return code %d: %s" % (proc.returncode, stderr)
-            )
-
         outlines = stdout.decode().splitlines()
         return outlines
 

--- a/ska_dbi/sqsh.py
+++ b/ska_dbi/sqsh.py
@@ -1,6 +1,7 @@
 import subprocess
 from pathlib import Path
 from astropy.table import Table
+from ska_dbi.common import DEFAULT_CONFIG, NoPasswordError
 
 SYBASE = "/soft/SYBASE16.0"
 ENV_VARS = [
@@ -11,6 +12,24 @@ SQSH_BIN = "/usr/local/bin/sqsh.bin"
 
 
 class Sqsh(object):
+    """
+    Class to interface with sqsh on HEAD to query the axafapstat or axafocat databases.
+
+    Example usage::
+
+      db = DBI(dbi='sqlite', server=dbfile, numpy=False, verbose=True)
+      db = DBI(dbi='sybase', server='sybase', user='aca_ops', database='aca')
+      db = DBI(dbi='sybase')   # Use defaults (same as above)
+
+    :param server: Server name (default = sqlsao)
+    :param user: User name (default = aca_ops)
+    :param passwd: Password (optional).  Read from aspect authorization dir if required and not supplied.
+    :param database: Database name (default = axafapstat)
+    :param sqshrc: sqshrc file (optional).  Read from aspect authorization dir if required and not supplied.
+    :param authdir: Directory containing authorization files
+
+    :rtype: Sqsh object
+    """
     def __init__(
         self,
         server=None,
@@ -21,18 +40,17 @@ class Sqsh(object):
         authdir="/proj/sot/ska/data/aspect_authorization",
         **kwargs,
     ):
-        DEFAULTS = {"server": "sqlsao", "user": "aca_ops", "database": "axafapstat"}
 
-        self.server = server or DEFAULTS.get("server")
-        self.user = user or DEFAULTS.get("user")
-        self.database = database or DEFAULTS.get("database")
+        self.server = server or DEFAULT_CONFIG['sybase'].get("server")
+        self.user = user or DEFAULT_CONFIG['sybase'].get("user")
+        self.database = database or DEFAULT_CONFIG['sybase'].get("database")
         self.passwd = passwd
         self.sqshrc = sqshrc
 
         if not Path(SYBASE).exists():
-            raise RuntimeError("SYBASE does not exist: %s" % SYBASE)
+            raise RuntimeError(f"SYBASE does not exist: {SYBASE}")
         if not Path(SQSH_BIN).exists():
-            raise RuntimeError("sqsh.bin does not exist: %s" % SQSH_BIN)
+            raise RuntimeError(f"sqsh.bin does not exist: {SQSH_BIN}")
 
         if self.passwd is None and self.sqshrc is None:
             sqshrc_file = (
@@ -42,7 +60,7 @@ class Sqsh(object):
                 self.sqshrc = sqshrc_file
             else:
                 raise NoPasswordError(
-                    "None supplied and unable to read inferred sqshrc file %s" % e
+                    f"None supplied and unable to read inferred sqshrc file {sqshrc_file}"
                 )
 
     def __enter__(self):
@@ -52,13 +70,27 @@ class Sqsh(object):
     def __exit__(self, exc_type, exc_value, traceback):
         """
         Context manager exit run time context.
-
-        Close connection.  By the implicit "return None" this will raise any exceptions
-        after closing.
         """
         pass
 
-    def fetchall(self, query):
+
+    def fetch(self, query):
+        """
+        Execute a query and return all returned sql rows a list of lines.
+
+        Note that this doesn't do anything fancy with the types of the return columns.
+        Python Sybase, for example, handled Sybase datetime columns as Python datetimes types
+        and here they are just strings.
+
+        Parameters
+        ----------
+        query : str
+            SQL query to execute (select statements are expected for our use cases)
+
+        Returns
+        -------
+        list of str
+        """
         envs = ENV_VARS
         if self.sqshrc is not None:
             envs = envs + [f"SQSHRC={self.sqshrc}"]
@@ -89,5 +121,48 @@ class Sqsh(object):
                 "sqsh failed with return code %d: %s" % (proc.returncode, stderr)
             )
 
-        tab = Table.read(stdout.decode().splitlines(), format="ascii.csv")
+        outlines = stdout.decode().splitlines()
+        return outlines
+
+
+    def fetchall(self, query):
+        """
+        Fetches all the rows returned by the query.
+
+        Parameters
+        ----------
+        query : str
+            The SQL query to execute.
+
+        Returns
+        -------
+        astropy.table.Table or None
+            The table containing the fetched rows, or None if no rows are returned.
+        """
+        outlines = self.fetch(query)
+        # Sqsh should always be returning a header line -- return None if that's it.
+        if len(outlines) <= 1:
+            return None
+        tab = Table.read(outlines, format="ascii.csv")
         return tab
+
+
+    def fetchone(self, query):
+        """
+        Fetches the first row returned by the query.
+
+        Parameters
+        ----------
+        query : str
+            The SQL query to execute.
+
+        Returns
+        -------
+        astropy.table.Row or None
+        """
+        outlines = self.fetch(query)
+        # Sqsh should always be returning a header line -- return None if that's it.
+        if len(outlines) <= 1:
+            return None
+        tab = Table.read(outlines, format="ascii.csv")
+        return tab[0]

--- a/ska_dbi/sqsh.py
+++ b/ska_dbi/sqsh.py
@@ -140,9 +140,6 @@ class Sqsh(object):
             The table containing the fetched rows, or None if no rows are returned.
         """
         outlines = self.fetch(query)
-        # Sqsh should always be returning a header line -- return None if that's it.
-        if len(outlines) <= 1:
-            return None
         tab = Table.read(outlines, format="ascii.csv")
         return tab
 

--- a/ska_dbi/sqsh.py
+++ b/ska_dbi/sqsh.py
@@ -120,8 +120,9 @@ class Sqsh(object):
 
         Returns
         -------
-        astropy.table.Table or None
-            The table containing the fetched rows, or None if no rows are returned.
+        astropy.table.Table
+            The table containing the fetched rows. If there are no rows that match the query,
+            a zero-length table is returned.
         """
         outlines = self.fetch(query)
         tab = Table.read(outlines, format="ascii.csv")

--- a/ska_dbi/sqsh.py
+++ b/ska_dbi/sqsh.py
@@ -1,0 +1,93 @@
+import subprocess
+from pathlib import Path
+from astropy.table import Table
+
+SYBASE = "/soft/SYBASE16.0"
+ENV_VARS = [
+    f"SYBASE={SYBASE}",
+    "LD_LIBRARY_PATH=/soft/SYBASE16.0/OCS-16_0/lib:/soft/SYBASE16.0/OCS-16_0/lib3p64:/soft/SYBASE16.0/OCS-16_0/lib3p",
+]
+SQSH_BIN = "/usr/local/bin/sqsh.bin"
+
+
+class Sqsh(object):
+    def __init__(
+        self,
+        server=None,
+        user=None,
+        passwd=None,
+        database=None,
+        sqshrc=None,
+        authdir="/proj/sot/ska/data/aspect_authorization",
+        **kwargs,
+    ):
+        DEFAULTS = {"server": "sqlsao", "user": "aca_ops", "database": "axafapstat"}
+
+        self.server = server or DEFAULTS.get("server")
+        self.user = user or DEFAULTS.get("user")
+        self.database = database or DEFAULTS.get("database")
+        self.passwd = passwd
+        self.sqshrc = sqshrc
+
+        if not Path(SYBASE).exists():
+            raise RuntimeError("SYBASE does not exist: %s" % SYBASE)
+        if not Path(SQSH_BIN).exists():
+            raise RuntimeError("sqsh.bin does not exist: %s" % SQSH_BIN)
+
+        if self.passwd is None and self.sqshrc is None:
+            sqshrc_file = (
+                Path(authdir) / f"sqsh-{self.server}-{self.database}-{self.user}"
+            )
+            if sqshrc_file.exists():
+                self.sqshrc = sqshrc_file
+            else:
+                raise NoPasswordError(
+                    "None supplied and unable to read inferred sqshrc file %s" % e
+                )
+
+    def __enter__(self):
+        """Context manager enter runtime context.  No action required, just return self."""
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        """
+        Context manager exit run time context.
+
+        Close connection.  By the implicit "return None" this will raise any exceptions
+        after closing.
+        """
+        pass
+
+    def fetchall(self, query):
+        envs = ENV_VARS
+        if self.sqshrc is not None:
+            envs = envs + [f"SQSHRC={self.sqshrc}"]
+        cmd = [
+            SQSH_BIN,
+            "-X",
+            "-S",
+            self.server,
+            "-U",
+            self.user,
+            "-D",
+            self.database,
+            "-m",
+            "csv",
+            "-C",
+            query,
+        ]
+        if self.passwd is not None:
+            cmd += ["-P", self.passwd]
+        cmd = ["env"] + envs + cmd
+
+        proc = subprocess.Popen(
+            cmd, stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE
+        )
+        stdout, stderr = proc.communicate()
+        if proc.returncode != 0:
+            raise RuntimeError(
+                "sqsh failed with return code %d: %s" % (proc.returncode, stderr)
+            )
+
+        tab = Table.read(stdout.decode().splitlines(), format="ascii.csv")
+        return tab

--- a/ska_dbi/tests/test_dbi.py
+++ b/ska_dbi/tests/test_dbi.py
@@ -19,7 +19,7 @@ HAS_SYBASE = ('SYBASE_OCS' in os.environ and
               os.path.exists(
                 os.path.join(os.environ['SYBASE'],
                              os.environ['SYBASE_OCS'],
-                             'python', 'python34_64r', 'lib', 'sybpydb.so')))
+                             'python', 'python39_64r', 'lib', 'sybpydb.so')))
 
 
 with open(os.path.join(os.path.dirname(__file__), 'ska_dbi_test_table.sql')) as fh:

--- a/ska_dbi/tests/test_dbi.py
+++ b/ska_dbi/tests/test_dbi.py
@@ -6,6 +6,7 @@ Usage:
 """
 
 import os
+import sys
 import pytest
 import numpy as np
 import tempfile
@@ -13,9 +14,13 @@ import tempfile
 from ska_dbi import DBI
 
 
-# If the SYBASE_OCS environment variable is set (from flt_envs) and the module exists
+# If Python version >= 3.7 and less than 3.11
+# and the SYBASE_OCS environment variable is set (from flt_envs) and the module exists
 # on the system, do the Sybase tests.
-HAS_SYBASE = ('SYBASE_OCS' in os.environ and
+HAS_SYBASE = (
+    sys.version_info.major == 3 and
+    (sys.version_info.minor < 11 and sys.version_info.minor >= 7) and
+    'SYBASE_OCS' in os.environ and
               os.path.exists(
                 os.path.join(os.environ['SYBASE'],
                              os.environ['SYBASE_OCS'],

--- a/ska_dbi/tests/test_dbi.py
+++ b/ska_dbi/tests/test_dbi.py
@@ -14,19 +14,6 @@ import tempfile
 from ska_dbi import DBI
 
 
-# If Python version >= 3.7 and less than 3.11
-# and the SYBASE_OCS environment variable is set (from flt_envs) and the module exists
-# on the system, do the Sybase tests.
-HAS_SYBASE = (
-    sys.version_info.major == 3 and
-    (sys.version_info.minor < 11 and sys.version_info.minor >= 7) and
-    'SYBASE_OCS' in os.environ and
-              os.path.exists(
-                os.path.join(os.environ['SYBASE'],
-                             os.environ['SYBASE_OCS'],
-                             'python', 'python39_64r', 'lib', 'sybpydb.so')))
-
-
 with open(os.path.join(os.path.dirname(__file__), 'ska_dbi_test_table.sql')) as fh:
     TEST_TABLE_SQL = fh.read().strip()
 
@@ -107,18 +94,6 @@ class TestSqliteWithNumpy(DBI_BaseTests):
 
 class TestSqliteWithoutNumpy(DBI_BaseTests):
     db_config = dict(dbi='sqlite', numpy=False)
-
-
-@pytest.mark.skipif('not HAS_SYBASE', reason='No SYBASE_OCS and/or sybpydb.so')
-class TestSybaseWithNumpy(DBI_BaseTests):
-    db_config = dict(dbi='sybase', server='sybase', user='aca_test',
-                     database='aca_tstdb', numpy=True)
-
-
-@pytest.mark.skipif('not HAS_SYBASE', reason='No SYBASE_OCS and/or sybpydb.so')
-class TestSybaseWithoutNumpy(DBI_BaseTests):
-    db_config = dict(dbi='sybase', server='sybase', user='aca_test',
-                     database='aca_tstdb', numpy=False)
 
 
 def test_context_manager():

--- a/ska_dbi/tests/test_sqsh.py
+++ b/ska_dbi/tests/test_sqsh.py
@@ -1,0 +1,16 @@
+from ska_dbi import Sqsh
+
+
+def test_read_axafapstat_table():
+    s = Sqsh()
+    query = "select * from aspect_1 where obsid=5438"
+    dat = s.fetchall(query)
+    assert len(dat) >= 4
+    assert dat["obsid"][0] == 5438
+    assert dat[dat["revision"] == 1]['ascdsver'] == '7.6.3'
+
+
+
+
+
+

--- a/ska_dbi/tests/test_sqsh.py
+++ b/ska_dbi/tests/test_sqsh.py
@@ -37,3 +37,11 @@ def test_fetchone_axafocat_empty():
     query = "select * from target where obsid=80000"
     dat = s.fetchone(query)
     assert dat is None
+
+
+def test_fetchone_axafapstat_context():
+    with Sqsh() as s:
+        query = "select * from aspect_1 where obsid=5438 and revision=1"
+        dat = s.fetchone(query)
+        assert dat["obsid"] == 5438
+        assert dat['ascdsver'] == '7.6.3'

--- a/ska_dbi/tests/test_sqsh.py
+++ b/ska_dbi/tests/test_sqsh.py
@@ -1,6 +1,10 @@
+import pytest
+from testr.test_helper import on_head_network
 from ska_dbi.sqsh import Sqsh
+from ska_dbi.common import NoPasswordError
 
 
+@pytest.mark.skipif(not on_head_network, reason="Test only runs on HEAD network")
 def test_fetch_axafapstat_lines():
     s = Sqsh()
     query = "select * from aspect_1 where obsid=5438"
@@ -8,6 +12,7 @@ def test_fetch_axafapstat_lines():
     assert len(lines) >= 5
 
 
+@pytest.mark.skipif(not on_head_network, reason="Test only runs on HEAD network")
 def test_fetchall_axafapstat():
     s = Sqsh()
     query = "select * from aspect_1 where obsid=5438"
@@ -17,6 +22,7 @@ def test_fetchall_axafapstat():
     assert dat[dat["revision"] == 1]['ascdsver'] == '7.6.3'
 
 
+@pytest.mark.skipif(not on_head_network, reason="Test only runs on HEAD network")
 def test_fetchall_axafocat_empty():
     s = Sqsh(server='sqlsao', user='aca_ops', database='axafocat')
     query = "select * from target where obsid=80000"
@@ -24,6 +30,7 @@ def test_fetchall_axafocat_empty():
     assert len(dat) == 0
 
 
+@pytest.mark.skipif(not on_head_network, reason="Test only runs on HEAD network")
 def test_fetchone_axafapstat():
     s = Sqsh()
     query = "select * from aspect_1 where obsid=5438 and revision=1"
@@ -32,6 +39,7 @@ def test_fetchone_axafapstat():
     assert dat['ascdsver'] == '7.6.3'
 
 
+@pytest.mark.skipif(not on_head_network, reason="Test only runs on HEAD network")
 def test_fetchone_axafocat_empty():
     s = Sqsh(server='sqlsao', user='aca_ops', database='axafocat')
     query = "select * from target where obsid=80000"
@@ -39,9 +47,24 @@ def test_fetchone_axafocat_empty():
     assert dat is None
 
 
+@pytest.mark.skipif(not on_head_network, reason="Test only runs on HEAD network")
 def test_fetchone_axafapstat_context():
     with Sqsh() as s:
         query = "select * from aspect_1 where obsid=5438 and revision=1"
         dat = s.fetchone(query)
         assert dat["obsid"] == 5438
         assert dat['ascdsver'] == '7.6.3'
+
+
+@pytest.mark.skipif(not on_head_network, reason="Test only runs on HEAD network")
+def test_no_passwd():
+    with pytest.raises(NoPasswordError):
+        s = Sqsh(server='sqlsao', user='aca_nonexistent', database='axafapstat')
+
+
+@pytest.mark.skipif(not on_head_network, reason="Test only runs on HEAD network")
+def test_fetch_axafapstat_lines():
+    s = Sqsh()
+    query = "select * from aspect_1 where obsid=5438"
+    lines = s.fetch(query)
+    assert len(lines) >= 5

--- a/ska_dbi/tests/test_sqsh.py
+++ b/ska_dbi/tests/test_sqsh.py
@@ -16,15 +16,10 @@ def test_fetchall_axafapstat():
     assert dat["obsid"][0] == 5438
     assert dat[dat["revision"] == 1]['ascdsver'] == '7.6.3'
 
+
 def test_fetchone_axafapstat():
     s = Sqsh()
     query = "select * from aspect_1 where obsid=5438 and revision=1"
     dat = s.fetchone(query)
     assert dat["obsid"] == 5438
     assert dat['ascdsver'] == '7.6.3'
-
-
-
-
-
-

--- a/ska_dbi/tests/test_sqsh.py
+++ b/ska_dbi/tests/test_sqsh.py
@@ -1,4 +1,4 @@
-from ska_dbi import Sqsh
+from ska_dbi.sqsh import Sqsh
 
 
 def test_fetch_axafapstat_lines():
@@ -17,9 +17,23 @@ def test_fetchall_axafapstat():
     assert dat[dat["revision"] == 1]['ascdsver'] == '7.6.3'
 
 
+def test_fetchall_axafocat_empty():
+    s = Sqsh(server='sqlsao', user='aca_ops', database='axafocat')
+    query = "select * from target where obsid=80000"
+    dat = s.fetchall(query)
+    assert len(dat) == 0
+
+
 def test_fetchone_axafapstat():
     s = Sqsh()
     query = "select * from aspect_1 where obsid=5438 and revision=1"
     dat = s.fetchone(query)
     assert dat["obsid"] == 5438
     assert dat['ascdsver'] == '7.6.3'
+
+
+def test_fetchone_axafocat_empty():
+    s = Sqsh(server='sqlsao', user='aca_ops', database='axafocat')
+    query = "select * from target where obsid=80000"
+    dat = s.fetchone(query)
+    assert dat is None

--- a/ska_dbi/tests/test_sqsh.py
+++ b/ska_dbi/tests/test_sqsh.py
@@ -1,13 +1,27 @@
 from ska_dbi import Sqsh
 
 
-def test_read_axafapstat_table():
+def test_fetch_axafapstat_lines():
+    s = Sqsh()
+    query = "select * from aspect_1 where obsid=5438"
+    lines = s.fetch(query)
+    assert len(lines) >= 5
+
+
+def test_fetchall_axafapstat():
     s = Sqsh()
     query = "select * from aspect_1 where obsid=5438"
     dat = s.fetchall(query)
     assert len(dat) >= 4
     assert dat["obsid"][0] == 5438
     assert dat[dat["revision"] == 1]['ascdsver'] == '7.6.3'
+
+def test_fetchone_axafapstat():
+    s = Sqsh()
+    query = "select * from aspect_1 where obsid=5438 and revision=1"
+    dat = s.fetchone(query)
+    assert dat["obsid"] == 5438
+    assert dat['ascdsver'] == '7.6.3'
 
 
 

--- a/ska_dbi/tests/test_sqsh.py
+++ b/ska_dbi/tests/test_sqsh.py
@@ -4,7 +4,10 @@ from ska_dbi.sqsh import Sqsh
 from ska_dbi.common import NoPasswordError
 
 
-@pytest.mark.skipif(not on_head_network, reason="Test only runs on HEAD network")
+ON_HEAD_NETWORK = on_head_network()
+
+
+@pytest.mark.skipif("not ON_HEAD_NETWORK", reason="Test only runs on HEAD network")
 def test_fetch_axafapstat_lines():
     s = Sqsh()
     query = "select * from aspect_1 where obsid=5438"
@@ -12,7 +15,7 @@ def test_fetch_axafapstat_lines():
     assert len(lines) >= 5
 
 
-@pytest.mark.skipif(not on_head_network, reason="Test only runs on HEAD network")
+@pytest.mark.skipif("not ON_HEAD_NETWORK", reason="Test only runs on HEAD network")
 def test_fetchall_axafapstat():
     s = Sqsh()
     query = "select * from aspect_1 where obsid=5438"
@@ -22,7 +25,7 @@ def test_fetchall_axafapstat():
     assert dat[dat["revision"] == 1]['ascdsver'] == '7.6.3'
 
 
-@pytest.mark.skipif(not on_head_network, reason="Test only runs on HEAD network")
+@pytest.mark.skipif("not ON_HEAD_NETWORK", reason="Test only runs on HEAD network")
 def test_fetchall_axafocat_empty():
     s = Sqsh(server='sqlsao', user='aca_ops', database='axafocat')
     query = "select * from target where obsid=80000"
@@ -30,7 +33,7 @@ def test_fetchall_axafocat_empty():
     assert len(dat) == 0
 
 
-@pytest.mark.skipif(not on_head_network, reason="Test only runs on HEAD network")
+@pytest.mark.skipif("not ON_HEAD_NETWORK", reason="Test only runs on HEAD network")
 def test_fetchone_axafapstat():
     s = Sqsh()
     query = "select * from aspect_1 where obsid=5438 and revision=1"
@@ -39,7 +42,7 @@ def test_fetchone_axafapstat():
     assert dat['ascdsver'] == '7.6.3'
 
 
-@pytest.mark.skipif(not on_head_network, reason="Test only runs on HEAD network")
+@pytest.mark.skipif("not ON_HEAD_NETWORK", reason="Test only runs on HEAD network")
 def test_fetchone_axafocat_empty():
     s = Sqsh(server='sqlsao', user='aca_ops', database='axafocat')
     query = "select * from target where obsid=80000"
@@ -47,7 +50,7 @@ def test_fetchone_axafocat_empty():
     assert dat is None
 
 
-@pytest.mark.skipif(not on_head_network, reason="Test only runs on HEAD network")
+@pytest.mark.skipif("not ON_HEAD_NETWORK", reason="Test only runs on HEAD network")
 def test_fetchone_axafapstat_context():
     with Sqsh() as s:
         query = "select * from aspect_1 where obsid=5438 and revision=1"
@@ -56,13 +59,13 @@ def test_fetchone_axafapstat_context():
         assert dat['ascdsver'] == '7.6.3'
 
 
-@pytest.mark.skipif(not on_head_network, reason="Test only runs on HEAD network")
+@pytest.mark.skipif("not ON_HEAD_NETWORK", reason="Test only runs on HEAD network")
 def test_no_passwd():
     with pytest.raises(NoPasswordError):
         s = Sqsh(server='sqlsao', user='aca_nonexistent', database='axafapstat')
 
 
-@pytest.mark.skipif(not on_head_network, reason="Test only runs on HEAD network")
+@pytest.mark.skipif("not ON_HEAD_NETWORK", reason="Test only runs on HEAD network")
 def test_fetch_axafapstat_lines():
     s = Sqsh()
     query = "select * from aspect_1 where obsid=5438"


### PR DESCRIPTION
## Description

A replacement for our sybase axafapstat calls using sqsh.

## Interface impacts
Removes sybase as a possible ska_dbi.DBI dbi.

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] Linux (checked 3.10 and 3.11)
- [x] Mac

```ska3-jeanconn-fido> git rev-parse HEAD
785b2b01349894ff5a2d398d9581b82d5718d1fe
ska3-jeanconn-fido> pytest
=================================================================== test session starts ===================================================================
platform linux -- Python 3.10.8, pytest-7.2.1, pluggy-1.0.0
rootdir: /proj/sot/ska/jeanproj/git, configfile: pytest.ini
plugins: anyio-3.6.2, timeout-2.1.0
collected 30 items                                                                                                                                        

ska_dbi/tests/test_dbi.py .......................                                                                                                   [ 76%]
ska_dbi/tests/test_sqsh.py .......                                                                                                                  [100%]

=================================================================== 30 passed in 3.44s
```

```
(ska3-flight-2024.0rc7) jeanconn-fido> pytest
============================= test session starts ==============================
platform linux -- Python 3.11.7, pytest-7.4.4, pluggy-1.3.0
rootdir: /proj/sot/ska/jeanproj/git
configfile: pytest.ini
plugins: timeout-2.2.0, anyio-4.2.0
collected 30 items                                                             

ska_dbi/tests/test_dbi.py .......................                                                                              [ 76%]
ska_dbi/tests/test_sqsh.py .......                                                                                             [100%]

========================================================== warnings summary ==========================================================
../../../../../../fido.real/conda/envs/ska3-flight-2024.0rc7/lib/python3.11/site-packages/ska_helpers/version.py:25
  /fido.real/conda/envs/ska3-flight-2024.0rc7/lib/python3.11/site-packages/ska_helpers/version.py:25: DeprecationWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html
    from pkg_resources import DistributionNotFound, get_distribution

../../../../../../fido.real/conda/envs/ska3-flight-2024.0rc7/lib/python3.11/site-packages/pkg_resources/__init__.py:2868
  /fido.real/conda/envs/ska3-flight-2024.0rc7/lib/python3.11/site-packages/pkg_resources/__init__.py:2868: DeprecationWarning: Deprecated call to `pkg_resources.declare_namespace('sphinxcontrib')`.
  Implementing implicit namespace packages (as specified in PEP 420) is preferred to `pkg_resources.declare_namespace`. See https://setuptools.pypa.io/en/latest/references/keywords.html#keyword-namespace-packages
    declare_namespace(pkg)

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
=================================================== 30 passed, 2 warnings in 1.99s
```

```
MacOS
(ska3) flame:ska_dbi jean$ pytest
=============================================================== test session starts ===============================================================
platform darwin -- Python 3.10.8, pytest-7.2.1, pluggy-1.0.0
rootdir: /Users/jean/git, configfile: pytest.ini
plugins: timeout-2.1.0, anyio-3.6.2
collected 30 items                                                                                                                                

ska_dbi/tests/test_dbi.py .......................                                                                                           [ 76%]
ska_dbi/tests/test_sqsh.py sssssss                                                                                                          [100%]

========================================================== 23 passed, 7 skipped in 1.24s
```

Independent check of unit tests by [REVIEWER NAME]
- [ ] [PLATFORM]:

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
Functionally tested with use in https://github.com/sot/mica/pull/289
